### PR TITLE
Export props & add 'use client' directive

### DIFF
--- a/packages/react/src/components/Box/index.ts
+++ b/packages/react/src/components/Box/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Box';
+export { default, BoxProps } from './Box';

--- a/packages/react/src/components/Card/index.ts
+++ b/packages/react/src/components/Card/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Card';
+export { default, CardProps } from './Card';

--- a/packages/react/src/components/Form/ChoiceInput.tsx
+++ b/packages/react/src/components/Form/ChoiceInput.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { forwardRef, InputHTMLAttributes } from 'react';
 import styles from '@compassion-design-system/core/src/components/Form/radio-checkbox.module.css';
 import common from '@compassion-design-system/core/src/components/Form/form-common.module.css';

--- a/packages/react/src/components/Form/InputGroup.tsx
+++ b/packages/react/src/components/Form/InputGroup.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { forwardRef } from 'react';
 
 import Input from './Input';

--- a/packages/react/src/components/Form/PinField.tsx
+++ b/packages/react/src/components/Form/PinField.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   ChangeEvent,
   KeyboardEvent,

--- a/packages/react/src/components/Form/Select.tsx
+++ b/packages/react/src/components/Form/Select.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { forwardRef, InputHTMLAttributes, ReactElement } from 'react';
 import styles from '@compassion-design-system/core/src/components/Form/input-group.module.css';
 import common from '@compassion-design-system/core/src/components/Form/form-common.module.css';

--- a/packages/react/src/components/Form/SelectField.tsx
+++ b/packages/react/src/components/Form/SelectField.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { forwardRef } from 'react';
 
 import { FieldContainer } from './Helpers';

--- a/packages/react/src/components/Form/SelectGroup.tsx
+++ b/packages/react/src/components/Form/SelectGroup.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { forwardRef } from 'react';
 
 import { SelectFieldProps } from './SelectField';

--- a/packages/react/src/components/Form/TextArea.tsx
+++ b/packages/react/src/components/Form/TextArea.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { forwardRef, InputHTMLAttributes, useCallback, useState } from 'react';
 import styles from '@compassion-design-system/core/src/components/Form/textarea.module.css';
 import common from '@compassion-design-system/core/src/components/Form/form-common.module.css';

--- a/packages/react/src/components/Form/TextField.tsx
+++ b/packages/react/src/components/Form/TextField.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { forwardRef } from 'react';
 import '@compassion-design-system/core/src/components/Form/form-common.module.css';
 

--- a/packages/react/src/components/Form/index.ts
+++ b/packages/react/src/components/Form/index.ts
@@ -1,9 +1,9 @@
-export { default as Input } from './Input';
-export { default as TextField } from './TextField';
-export { default as InputGroup } from './InputGroup';
-export { default as TextArea } from './TextArea';
-export { default as Select } from './Select';
-export { default as SelectField } from './SelectField';
-export { default as SelectGroup } from './SelectGroup';
-export { default as ChoiceInput } from './ChoiceInput';
-export { default as PinField } from './PinField';
+export { default as Input, InputProps } from './Input';
+export { default as TextField, TextFieldProps } from './TextField';
+export { default as InputGroup, InputGroupProps } from './InputGroup';
+export { default as TextArea, TextAreaFieldProps } from './TextArea';
+export { default as Select, SelectProps } from './Select';
+export { default as SelectField, SelectFieldProps } from './SelectField';
+export { default as SelectGroup, SelectGroupProps } from './SelectGroup';
+export { default as ChoiceInput, ChoiceInputProps } from './ChoiceInput';
+export { default as PinField, PinFieldProps } from './PinField';

--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { forwardRef, MouseEvent, ReactNode, HTMLProps } from 'react';
 import styles from '@compassion-design-system/core/src/components/Modal/modal.module.css';
 import { X } from '../icons';

--- a/packages/react/src/components/Modal/index.ts
+++ b/packages/react/src/components/Modal/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Modal';
+export { default, ModalProps } from './Modal';

--- a/packages/react/src/components/Table/Table.test.tsx
+++ b/packages/react/src/components/Table/Table.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import Table from './Table';
+import Table, { Column } from './Table';
 
 describe('Table', () => {
   it('should render 3 columns and 3 rows', () => {

--- a/packages/react/src/components/Table/Table.tsx
+++ b/packages/react/src/components/Table/Table.tsx
@@ -99,7 +99,7 @@ function TableInner<Row>(
 
 const TableWithRef = forwardRef(TableInner);
 
-type TableWithRefProps<T> = TableProps<T> & {
+export type TableWithRefProps<T> = TableProps<T> & {
   mRef?: Ref<HTMLTableElement>;
 };
 

--- a/packages/react/src/components/Table/index.ts
+++ b/packages/react/src/components/Table/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Table';
+export { default, Column, TableWithRefProps } from './Table';

--- a/packages/react/src/components/TextBox/index.ts
+++ b/packages/react/src/components/TextBox/index.ts
@@ -1,1 +1,1 @@
-export { default } from './TextBox';
+export { default, TextBoxProps } from './TextBox';

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -1,19 +1,32 @@
 export { default as Button, ButtonProps } from './Button';
-export { default as Modal } from './Modal';
+export { default as Modal, ModalProps } from './Modal';
 export { default as Icon, IconProps } from './Icon';
-export { default as Table } from './Table';
+export {
+  default as Table,
+  Column as TableColumn,
+  TableWithRefProps as TableProps,
+} from './Table';
 export { NavItem, NavItemProps } from './Nav';
-export { default as Card } from './Card';
-export { default as TextBox } from './TextBox';
-export { default as Box } from './Box';
+export { default as Card, CardProps } from './Card';
+export { default as TextBox, TextBoxProps } from './TextBox';
+export { default as Box, BoxProps } from './Box';
 export {
   Input,
+  InputProps,
   InputGroup,
+  InputGroupProps,
   TextField,
+  TextFieldProps,
   TextArea,
+  TextAreaFieldProps,
   Select,
+  SelectProps,
   SelectField,
+  SelectFieldProps,
   SelectGroup,
+  SelectGroupProps,
   ChoiceInput,
+  ChoiceInputProps,
   PinField,
+  PinFieldProps,
 } from './Form';


### PR DESCRIPTION
- Export all component props so that consumers can easily type their props when using CDS components
- Add 'use client' directive to interactive components for Next.js 13 consumers